### PR TITLE
update redirect

### DIFF
--- a/node-github/index.html
+++ b/node-github/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0;URL=https://octokit.github.io/node-github/" />
+    <meta http-equiv="refresh" content="0;URL=https://octokit.github.io/rest.js/" />
     <meta charset="utf-8" />
-    <title>Location changed to octokit.github.io/node-github/</title>
+    <title>Location changed to octokit.github.io/rest.js/</title>
   </head>
   <body>
-  <p>Location changed to <a href="https://octokit.github.io/node-github/" rel="nofollow">octokit.github.io/node-github/</a>.</p>
+  <p>Location changed to <a href="https://octokit.github.io/rest.js/" rel="nofollow">octokit.github.io/rest.js/</a>.</p>
   <script>
-    window.location.href = "https://octokit.github.io/node-github/";
+    window.location.href = "https://octokit.github.io/rest.js/";
   </script>
  </body>
 </html>


### PR DESCRIPTION
We renamed the repository from `node-github` to `rest.js`
see https://github.com/octokit/rest.js/releases/tag/v14.0.0